### PR TITLE
If no episodes found, null is returned from endpoint

### DIFF
--- a/lib/imdb.js
+++ b/lib/imdb.js
@@ -72,7 +72,7 @@ var TVShow = (function (_super) {
         }
         function onEnd() {
             var eps = episodeList;
-            if(eps === "") {
+            if(eps === "" || eps === "null") {
                 return cb(new Error("could not get episodes"), null);
             }
             var episodes = [];


### PR DESCRIPTION
`JSON.parse("null") === null`, ie: `JSON.parse(eps)[tvShow.title]` fails.
