### PR TITLE
deanclatworthy with .com in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A non-scraping, functional node.js interface to imdb
 
 # PROBLEMS
 
-**deanclatworthy has gone down. I'm looking at alternatives and would
+**deanclatworthy.com/imdb has gone down. I'm looking at alternatives and would
 appreciate suggestions/PRs**
 
 # Badges


### PR DESCRIPTION
When I read deanclatworthy the first time I don't understand is more understandable with the `.com`