### PR TITLE
tolerate inconsistencies in API, such as N/A for release date and rating

### DIFF
--- a/src/imdb.ts
+++ b/src/imdb.ts
@@ -175,7 +175,7 @@ export class Movie {
     /** leading actors that starred in the movie */
     public actors: string;
     /** date that the movie was originally released */
-    public released: Date;
+    public released?: Date;
     /** title of the movie */
     public name: string;
 
@@ -209,15 +209,14 @@ export class Movie {
             } else if (attr === "Released") {
                 const val = new Date(obj[attr]);
                 if (isNaN(val.getTime())) {
-                    throw new TypeError("invalid release date");
+                    this.released = undefined;
+                } else {
+                    this.released = val;
                 }
-                this.released = val;
             } else if (attr === "imdbRating") {
+                const key = trans_table[attr];
                 const val = parseFloat(obj[attr]);
-                if (isNaN(val)) {
-                    throw new TypeError("invalid rating");
-                }
-                this[trans_table[attr]] = parseFloat(obj[attr]);
+                this[key] = isNaN(val) ? 0 : val;
             } else if (trans_table[attr] !== undefined) {
                 this[trans_table[attr]] = obj[attr];
             } else {

--- a/test/test-movie.ts
+++ b/test/test-movie.ts
@@ -87,13 +87,13 @@ describe("Movie", () => {
         assert.deepEqual(mov.series, false, "not a series");
         assert.deepEqual(mov.imdburl, "https://www.imdb.com/title/tt653921", "url formulated correctly");
     });
-    it("creates a movie with invalid score", () => {
-        const mov = Object.assign(Object.create(orig_movie), {imdbRating: "foo"});
-        assert.throws(() => new imdb.Movie(mov), TypeError);
+    it("creates a movie with invalid rating", () => {
+        const mov = Object.assign(Object.create(orig_movie), {imdbRating: "N/A"});
+        assert.equal(new imdb.Movie(mov).rating, 0);
     });
-    it("creates a movie with bad release data", () => {
-        const mov = Object.assign(Object.create(orig_movie), {Released: "foo"});
-        assert.throws(() => new imdb.Movie(mov), TypeError);
+    it("creates a movie with bad release date", () => {
+        const mov = Object.assign(Object.create(orig_movie), {Released: "N/A"});
+        assert.isUndefined(new imdb.Movie(mov).released);
     });
     it("creates a movie with no year", () => {
         let mov = Object.assign(Object.create(orig_movie));
@@ -152,7 +152,7 @@ describe("Episode", () => {
 
     it("creates an episode with an invalid release", () => {
         const ep = Object.assign(Object.create(orig_tv), {Released: "foo"});
-        assert.throws(() => new imdb.Episode(ep, 30), TypeError);
+        assert.isUndefined(new imdb.Episode(ep, 30).released);
     });
 
     it("creates an episode with an invalid year", () => {


### PR DESCRIPTION
I was trying out the library and ran into an error for invalid release date. I dug into it myself and saw the value coming from the API as "N/A". I then saw this issue open already for a similar problem regarding the imdbRating field: https://github.com/worr/node-imdb-api/issues/63

Recreating the issue:
```
cli.get({'name': 'Bojack Horseman'})
   .then((show) => show.episodes() )
   .then(console.log)
   .catch(console.error)
```
results in:

> TypeError: invalid release date

The raw data being processed in the constructor:

> { Title: 'Love And/Or Marriage',
>   Released: 'N/A',
>   Episode: '5',
>   imdbRating: '8.1',
>   imdbID: 'tt5218444' }

It was trivial enough for me to fix to get myself going, so I figured I'd share what I had done. While I definitely think setting to 0 if the rating is isNaN makes sense, I wasn't convinced what was best for the missing Released Date field. I ended up just setting it to null.