### PR TITLE
Fix undefined "end_year"

### DIFF
--- a/src/imdb.ts
+++ b/src/imdb.ts
@@ -437,7 +437,7 @@ export class TVShow extends Movie {
    */
   constructor(obj: OmdbTvshow, opts: MovieOpts) {
     super(obj);
-    const years = this._yearData.split("-");
+    const years = this._yearData.split(/[–-]/);
     this.start_year = parseInt(years[0], 10);
     this.end_year = parseInt(years[1], 10) ? parseInt(years[1], 10) : undefined;
     this.totalseasons = parseInt(obj.totalSeasons, 10);


### PR DESCRIPTION
```ts
await imdb.get({ name: 'Dark' }, { apiKey: 'foo' }).then(res => [res.start_year, res.end_year]);
```
```ts
[2017, undefined]
```

This line will convert `_this._yearData` from `"2017–2020"` to `["2017–2020"]` instead of expected `["2017", "2020"]`
https://github.com/worr/node-imdb-api/blob/d17c0f113461d3c4ab502c39f82dc54f9c366905/src/imdb.ts#L440

`–` hyphen
`-` minus sign